### PR TITLE
Incorporate oslo_log for logging

### DIFF
--- a/ardana_installer_server/main.py
+++ b/ardana_installer_server/main.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 from flask import Flask
 from flask_cors import CORS
-import logging
 from oslo_config import cfg
+from oslo_log import log as logging
 
 from ardana_installer_server import ardana
 from ardana_installer_server import config  # noqa: F401
@@ -24,20 +24,15 @@ from ardana_installer_server import socketio
 from ardana_installer_server import suse_manager
 from ardana_installer_server import ui
 
-
-# attempt to set the log file to /var/log/cloudinstaller/install.log, but if
-# it's not writable, still configure default logging level to DEBUG
-try:
-    logging.basicConfig(level=logging.DEBUG,
-                        filename='/var/log/cloudinstaller/install.log')
-except IOError:
-    logging.basicConfig(level=logging.DEBUG)
-
 LOG = logging.getLogger(__name__)
-
 CONF = cfg.CONF
+logging.register_options(CONF)
+
 # Load config options from config file or command line
 CONF()
+
+# Setup the logging per the config options
+logging.setup(CONF, 'ardana_installer_service')
 
 app = Flask(__name__,
             static_url_path='',

--- a/ardana_installer_server/socket_proxy.py
+++ b/ardana_installer_server/socket_proxy.py
@@ -17,19 +17,14 @@ from flask import Blueprint
 from flask import copy_current_request_context
 from flask import request
 from flask_socketio import emit
-import logging
 from oslo_config import cfg
+from oslo_log import log as logging
 from socketIO_client import BaseNamespace
 from socketIO_client import SocketIO
 from urlparse import urlparse
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
-# TODO(gary): Remove these and provide for more general logging control
-logging.getLogger('socketIO-client').setLevel(logging.WARN)
-logging.getLogger('socketio').setLevel(logging.WARN)
-logging.getLogger('engineio').setLevel(logging.WARN)
-logging.getLogger('urllib3.connectionpool').setLevel(logging.INFO)
 
 bp = Blueprint('socket_proxy', __name__)
 

--- a/etc/config-generator.conf
+++ b/etc/config-generator.conf
@@ -3,3 +3,4 @@ output_file = etc/service.conf.sample
 wrap_width = 79
 namespace = ardana_installer_server
 namespace = oslo.config
+namespace = oslo.log

--- a/etc/devtest.conf
+++ b/etc/devtest.conf
@@ -1,3 +1,12 @@
+[DEFAULT]
+# Direct logs to a file if desired:
+# log_file = /tmp/server.log
+
+# The default level of INFO for engineio and socketio yields messages
+# for every line of every log that is transferred through the socket.
+# WARN avoids that.
+default_log_levels = engineio=WARN,socketio=WARN
+
 [general]
 host = 0.0.0.0
 port = 8081

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests         # APACHE2
 socketIO-client>=0.7.0 # MIT
 tinydb>=3.5.0    # MIT
 oslo.config>=5.1.0 # Apache-2.0
+oslo.log>=3.30.0 # Apache-2.0


### PR DESCRIPTION
Incorporate oslo_log for logging, which enables logging configuration to
be specified in the common configuration file.