### PR TITLE
Fixed issue for getting  suse manager server list and details

### DIFF
--- a/ardana_installer_server/suse_manager.py
+++ b/ardana_installer_server/suse_manager.py
@@ -28,8 +28,11 @@ Calls to SUSE Manager
 """
 
 
-def get_client(url):
-    context = None
+def get_client(url, secured):
+    context = ssl._create_default_https_context()
+    if secured == 'false':
+        context = ssl._create_unverified_context()
+
     client = xmlrpclib.Server(url, verbose=0, context=context)
     return client
 
@@ -74,8 +77,9 @@ def sm_server_list():
     try:
         key = request.headers.get('Auth-Token')
         url = request.headers.get('Suse-Manager-Url')
+        secured = request.headers.get('Secured')
 
-        client = get_client(url)
+        client = get_client(url, secured)
         server_list = client.system.listActiveSystems(key)
 
         for server in server_list:
@@ -83,8 +87,8 @@ def sm_server_list():
             server['last_checkin'] = str(server['last_checkin'])
 
         return jsonify(server_list)
-    except Exception:
-        abort(400)
+    except Exception as e:
+        return jsonify(error=str(e)), 400
 
 
 @bp.route("/api/v1/sm/servers/<id>")
@@ -92,8 +96,9 @@ def sm_server_details(id):
     try:
         key = request.headers.get('Auth-Token')
         url = request.headers.get('Suse-Manager-Url')
+        secured = request.headers.get('Secured')
 
-        client = get_client(url)
+        client = get_client(url, secured)
         detail_list = client.system.listActiveSystemsDetails(key, int(id))
 
         detail = detail_list[0]
@@ -101,5 +106,5 @@ def sm_server_details(id):
         detail['last_checkin'] = str(detail['last_checkin'])
 
         return jsonify(detail)
-    except Exception:
-        abort(400)
+    except Exception as e:
+        return jsonify(error=str(e)), 400

--- a/ardana_installer_server/suse_manager.py
+++ b/ardana_installer_server/suse_manager.py
@@ -28,9 +28,9 @@ Calls to SUSE Manager
 """
 
 
-def get_client(url, secured):
+def get_client(url, verify_ssl):
     context = ssl._create_default_https_context()
-    if secured == 'false':
+    if verify_ssl == 'false':
         context = ssl._create_unverified_context()
 
     client = xmlrpclib.Server(url, verbose=0, context=context)
@@ -41,8 +41,8 @@ def get_client(url, secured):
 def connection_test():
     context = ssl._create_default_https_context()
 
-    secured = request.headers.get('Secured')
-    if secured == 'false':
+    verify_ssl = request.headers.get('Secured')
+    if verify_ssl == 'false':
         context = ssl._create_unverified_context()
 
     creds = request.get_json() or {}
@@ -77,9 +77,9 @@ def sm_server_list():
     try:
         key = request.headers.get('Auth-Token')
         url = request.headers.get('Suse-Manager-Url')
-        secured = request.headers.get('Secured')
+        verify_ssl = request.headers.get('Secured')
 
-        client = get_client(url, secured)
+        client = get_client(url, verify_ssl)
         server_list = client.system.listActiveSystems(key)
 
         for server in server_list:
@@ -96,9 +96,9 @@ def sm_server_details(id):
     try:
         key = request.headers.get('Auth-Token')
         url = request.headers.get('Suse-Manager-Url')
-        secured = request.headers.get('Secured')
+        verify_ssl = request.headers.get('Secured')
 
-        client = get_client(url, secured)
+        client = get_client(url, verify_ssl)
         detail_list = client.system.listActiveSystemsDetails(key, int(id))
 
         detail = detail_list[0]

--- a/ardana_installer_server/suse_manager.py
+++ b/ardana_installer_server/suse_manager.py
@@ -47,7 +47,7 @@ def connection_test():
 
     creds = request.get_json() or {}
     port = "443"
-    if creds['port'] != 0:
+    if creds['port'] and creds['port'] != 0:
         port = creds['port']
     # check the host and port first before login
     try:

--- a/ardana_installer_server/suse_manager.py
+++ b/ardana_installer_server/suse_manager.py
@@ -46,7 +46,7 @@ def connection_test():
         context = ssl._create_unverified_context()
 
     creds = request.get_json() or {}
-    port = "8443"
+    port = "443"
     if creds['port'] != 0:
         port = creds['port']
     # check the host and port first before login


### PR DESCRIPTION
The checkin includes:

Passed the secured option to the function when get client to call
get servers or get server details.
If it is secured, will get context for https, otherwise use
unverified context.