### PR TITLE
Feat: use CustomJSONEncoder to jsonify datetime

### DIFF
--- a/ardana_installer_server/main.py
+++ b/ardana_installer_server/main.py
@@ -23,6 +23,7 @@ from ardana_installer_server import socket_proxy
 from ardana_installer_server import socketio
 from ardana_installer_server import suse_manager
 from ardana_installer_server import ui
+from ardana_installer_server.util import CustomJSONEncoder
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
@@ -42,6 +43,7 @@ app.register_blueprint(ui.bp)
 app.register_blueprint(oneview.bp)
 app.register_blueprint(suse_manager.bp)
 app.register_blueprint(socket_proxy.bp)
+app.json_encoder = CustomJSONEncoder
 CORS(app)
 
 

--- a/ardana_installer_server/suse_manager.py
+++ b/ardana_installer_server/suse_manager.py
@@ -82,10 +82,6 @@ def sm_server_list():
         client = get_client(url, verify_ssl)
         server_list = client.system.listActiveSystems(key)
 
-        for server in server_list:
-            # last_checkin is an object, which is not json-serializable
-            server['last_checkin'] = str(server['last_checkin'])
-
         return jsonify(server_list)
     except Exception as e:
         return jsonify(error=str(e)), 400
@@ -102,8 +98,6 @@ def sm_server_details(id):
         detail_list = client.system.listActiveSystemsDetails(key, int(id))
 
         detail = detail_list[0]
-        # last_checkin is an object, which is not json-serializable
-        detail['last_checkin'] = str(detail['last_checkin'])
 
         return jsonify(detail)
     except Exception as e:

--- a/ardana_installer_server/util.py
+++ b/ardana_installer_server/util.py
@@ -12,11 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from flask import abort
+from flask.json import JSONEncoder
+import datetime
 import requests
 import socket
+import xmlrpclib
 
 TIMEOUT = 2
 
+class CustomJSONEncoder(JSONEncoder):
+    def default(self, obj):
+        try:
+            if isinstance(obj, xmlrpclib.DateTime):
+                return datetime.datetime.strptime(
+                    obj.value, "%Y%m%dT%H:%M:%S").isoformat()
+            iterable = iter(obj)
+        except TypeError:
+            pass
+        else:
+            return list(iterable)
+        return JSONEncoder.default(self, obj)
 
 # Forward the url to the given destination
 def forward(url, request):


### PR DESCRIPTION
With this PR we use a Flask's `CustomJSONEncoder` to jsonify datetimes that come from SUMa.
Currently working on top of #9, waiting for it to be merged before reviewing this one.