### PR TITLE
Fix server post and put calls to check for valid source

### DIFF
--- a/ardana_installer_server/ui.py
+++ b/ardana_installer_server/ui.py
@@ -88,6 +88,9 @@ def insert_servers():
                                      "id or source"), 400
             sid = entry['id']
             src = entry['source']
+            if not set(src.split(',')).issubset(['sm', 'ov', 'manual']):
+                return jsonify(error="source=%s for id=%s is "
+                                     "invalid" % (src, sid)), 400
             server_entries = server_table.search(
                 (server.id == sid) & (server.source == src))
             if server_entries:
@@ -145,6 +148,9 @@ def update_server():
                                  "id or source"), 400
         sid = entry['id']
         src = entry['source']
+        if not set(src.split(',')).issubset(['sm', 'ov', 'manual']):
+            return jsonify(error="source=%s for id=%s is "
+                                 "invalid" % (src, sid)), 400
         server_entries = server_table.search(
             (server.id == sid) & (server.source == src))
         if not server_entries:


### PR DESCRIPTION
This is related to the fix I put in for SCRD-2127 which was about adding source validation in the create_query_str function to prevent the SQL injection attack. The create_query_str function was only used in the delete and the get calls, but not in the post and the put calls. This means that users can still insert data with invalid sources into the database. This change add the source validation logic to the post and the put calls.