### PR TITLE
Make requirements compatible with Pike and RPM packaging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-eventlet==0.20.0 # MIT
+eventlet>=0.20.0 # MIT
 Flask>=0.10,<1.0 # BSD
 Flask-Cors       # MIT
 Flask-SocketIO   # MIT
@@ -6,5 +6,5 @@ PyYAML>=3.10.0   # MIT
 requests         # APACHE2
 socketIO-client>=0.7.0 # MIT
 tinydb>=3.5.0    # MIT
-oslo.config>=5.1.0 # Apache-2.0
+oslo.config>=4.11.0 # Apache-2.0
 oslo.log>=3.30.0 # Apache-2.0


### PR DESCRIPTION
- do not require a specific version of eventlet. This can break when
  newer versions are installed (eg. in a RPM package based system) but
  pkg_resources complains that there is a version mismatch
- lower the needed oslo.config version to the one that is currently in
  u-c for stable/pike [1]

[1]
https://github.com/openstack/requirements/blob/stable/pike/upper-constraints.txt