### PR TITLE
Add get user call (bsc#1078354)

### DIFF
--- a/ardana_installer_server/ui.py
+++ b/ardana_installer_server/ui.py
@@ -21,6 +21,8 @@ import re
 import subprocess
 from tinydb import Query
 from tinydb import TinyDB
+import pwd
+import os
 
 bp = Blueprint('ui', __name__)
 SUCCESS = {"success": True}
@@ -271,3 +273,25 @@ def get_external_urls():
     urls = {k: v for (k, v) in cfg.CONF.urls.items()}
 
     return jsonify(urls)
+
+
+@bp.route("/api/v1/user", methods=['GET'])
+def get_user():
+    """Returns the username the service is running under
+
+    **Example Request**:
+
+    .. sourcecode:: http
+
+    GET /api/v1/user/1.1
+
+    **Example Response**:
+
+    .. sourcecode:: http
+    HTTP/1.1 200 OK
+
+    {"username": "myusername"}
+
+    """
+    user_dict = {'username': pwd.getpwuid(os.getuid()).pw_name}
+    return jsonify(user_dict)


### PR DESCRIPTION
The same call is available in ardana-service but having it in the shim layer is a better fit and can prevent the chance of not getting the user if/when ardana-service is not available.