### PR TITLE
Support python3

### DIFF
--- a/ardana_installer_server/socket_proxy.py
+++ b/ardana_installer_server/socket_proxy.py
@@ -21,7 +21,12 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from socketIO_client import BaseNamespace
 from socketIO_client import SocketIO
-from urlparse import urlparse
+import sys
+
+if sys.version_info.major < 3:
+    from urlparse import urlparse
+else:
+    from urllib.parse import urlparse
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)

--- a/ardana_installer_server/util.py
+++ b/ardana_installer_server/util.py
@@ -11,19 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 from flask import abort
 from flask.json import JSONEncoder
-import datetime
 import requests
 import socket
-import xmlrpclib
+import sys
+
+if sys.version_info.major < 3:
+    from xmlrpclib import DateTime
+else:
+    from xmlrpc.client import DateTime
 
 TIMEOUT = 2
+
 
 class CustomJSONEncoder(JSONEncoder):
     def default(self, obj):
         try:
-            if isinstance(obj, xmlrpclib.DateTime):
+            if isinstance(obj, DateTime):
                 return datetime.datetime.strptime(
                     obj.value, "%Y%m%dT%H:%M:%S").isoformat()
             iterable = iter(obj)
@@ -32,6 +38,7 @@ class CustomJSONEncoder(JSONEncoder):
         else:
             return list(iterable)
         return JSONEncoder.default(self, obj)
+
 
 # Forward the url to the given destination
 def forward(url, request):

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py27,py35,pep8
+envlist = py27,py34,pep8
 minversion = 2.0
 skipsdist = True
 
 [testenv]
-basepython = python2.7
 usedevelop = True
 install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt} {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
@@ -19,7 +18,6 @@ whitelist_externals =
 
 [testenv:runserver]
 passenv = REQUESTS_CA_BUNDLE
-basepython = python2.7
 commands =
   {envpython} ardana_installer_server/main.py --config-file etc/devtest.conf {posargs}
 
@@ -27,7 +25,7 @@ commands =
 commands =
   {envpython} {toxinidir}/setup.py test {posargs}
 
-[testenv:py35]
+[testenv:py34]
 commands =
   {envpython} {toxinidir}/setup.py test {posargs}
 


### PR DESCRIPTION
Add support for python3 while retaining support for python2.7, following
the openstack guide at https://wiki.openstack.org/wiki/Python3.  That
guide explains the rationale behind nearly all of the changes in this
commit, including using six and oslo_serialization libraries, print
function, items function, utf8 encoding, and so on.